### PR TITLE
update pico support for CircuitPython 8

### DIFF
--- a/w3by2 - pico/Readme.md
+++ b/w3by2 - pico/Readme.md
@@ -7,6 +7,8 @@ the bottom panel just gets clicked in, the pico can be screwed into the case wit
 ## Firmware
 copy the contents of the firmware folder onto the pi pico (CircuitPY drive) and add the kmk folder to it as well. step by step instructions can be found here in video form with more info about the pi pico - [youtube video](https://youtu.be/Q97bFwjQ_vQ)
 
+Tested with CircuitPython 8.2
+
 ## Wiring
 For the wiring the pins for the columns are `GP20, GP19, GP18` and the row pins are `GP17, GP16` all conveniently placed on one side of the microcontroller
 ![wiring](./img/wiring-hd.jpg)

--- a/w3by2 - pico/firmware/boot.py
+++ b/w3by2 - pico/firmware/boot.py
@@ -6,7 +6,7 @@ import usb_cdc
 import usb_hid
 
 # This is from the base kmk boot.py
-supervisor.set_next_stack_limit(4096 + 4096)
+supervisor.runtime.next_stack_limit = 4096 + 4096
 
 # If this key is held during boot, don't run the code which hides the storage and disables serial
 # To use another key just count its row and column and use those pins

--- a/w3by2 - pico/firmware/code.py
+++ b/w3by2 - pico/firmware/code.py
@@ -1,12 +1,4 @@
-print("Starting")
-
 import board
-import supervisor
-import board
-import digitalio
-import storage
-import usb_cdc
-import usb_hid
 
 from kmk.kmk_keyboard import KMKKeyboard
 from kmk.keys import KC


### PR DESCRIPTION
the previous code (CicruitPy 7) no longer works with the latest circuit python, (8.x) due to an API change.

set the stack size using the new supervisor.runtime.next_stack_limit attribute
  rather than the no-longer-supported supervisor.runtime.set_next_stack_limit method

remove unused imports in code.py

note in the readme that it's been testing with 8.2 so future folks have a clue as to what's going wrong